### PR TITLE
AOS-5764 Update aurora starter and spring boot parent

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ The application requires the starter  [aurora-spring-boot-mvc-starter](https://g
  - instrument ServerFilter with metrics
  - instrument logback with metrics
  
+Aurora also provides another starter, [aurora-spring-boot-webflux-starter](https://github.com/Skatteetaten/aurora-spring-boot-webflux-starter), which is intended for reactive applications.
 
 ## Log Configuration
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Default `maxmimumPoolSize` for Hikary is **10**. This has been reduced to **3** 
 
 ## Starters
 
-The application has one starter  [aurora-springboot2-starter](https://github.com/Skatteetaten/aurora-springboot2-starter/tree/master) in order to set up normal aurora requirements such as
+The application requires the starter  [aurora-spring-boot-mvc-starter](https://github.com/Skatteetaten/aurora-spring-boot-mvc-starter/tree/master) in order to set up normal aurora requirements such as
  - grouping properties into their own property sources
  - setting default properties for actuator
  - instrumenting RestTemplates with metrics
@@ -178,7 +178,7 @@ mechanisms.
 ### /prometheus - Metrics   
 
 The reference application sets up metrics as described in the 
-[aurora-springboot2-starter](https://github.com/Skatteetaten/aurora-springboot2-starter/tree/master)
+[aurora-spring-boot-mvc-starter](https://github.com/Skatteetaten/aurora-spring-boot-mvc-starter/tree/master)
 
 For applications that are deployed to OpenShift, metrics exposed at ```/prometheus``` (default, configurable) in the
 format required by Prometheus will be automatically scraped.

--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
       <dependency>
         <groupId>net.java.dev.jna</groupId>
         <artifactId>jna</artifactId>
-        <version>${java.version}</version>
+        <version>${jna.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -40,8 +40,10 @@
     <spring-boot-thin-layout.version>1.0.27.RELEASE</spring-boot-thin-layout.version>
     <asciidoctor-maven-plugin.version>2.1.0</asciidoctor-maven-plugin.version>
     <aws.sdk.version>2.16.85</aws.sdk.version>
-    <embedded-database-spring-test.version>1.6.3</embedded-database-spring-test.version>
+    <embedded-database-spring-test.version>2.0.1</embedded-database-spring-test.version>
     <s3mock.version>0.2.6</s3mock.version>
+    <zonky.version>1.3.0</zonky.version>
+    <jna.version>5.8.0</jna.version>
   </properties>
 
   <distributionManagement>
@@ -64,6 +66,11 @@
         <version>${aws.sdk.version}</version>
         <type>pom</type>
         <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>net.java.dev.jna</groupId>
+        <artifactId>jna</artifactId>
+        <version>${java.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -397,6 +404,12 @@
       <groupId>io.zonky.test</groupId>
       <artifactId>embedded-database-spring-test</artifactId>
       <version>${embedded-database-spring-test.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.zonky.test</groupId>
+      <artifactId>embedded-postgres</artifactId>
+      <version>${zonky.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>2.5.0</version>
+    <version>2.5.1</version>
     <relativePath />
   </parent>
 
@@ -25,7 +25,7 @@
     <sonar.java.coveragePlugin>jacoco</sonar.java.coveragePlugin>
     <sonar.coverage.exclusions>**/*Main.java</sonar.coverage.exclusions>
     <sonar.tests>src/test/groovy</sonar.tests>
-    <sonar-maven-plugin.version>3.7.0.1746</sonar-maven-plugin.version>
+    <sonar-maven-plugin.version>3.9.0.2155</sonar-maven-plugin.version>
     <gmavenplus-plugin.version>1.12.1</gmavenplus-plugin.version>
     <groovy.version>2.5.14</groovy.version>
     <spock.version>1.3-groovy-2.5</spock.version>
@@ -34,12 +34,12 @@
     <jacoco-maven-plugin.version>0.8.7</jacoco-maven-plugin.version>
     <maven-enforcer-plugin.version>1.4.1</maven-enforcer-plugin.version>
     <maven-site-plugin.version>3.9.1</maven-site-plugin.version>
-    <maven-checkstyle-plugin.version>3.1.1</maven-checkstyle-plugin.version>
+    <maven-checkstyle-plugin.version>3.1.2</maven-checkstyle-plugin.version>
     <checkstyle-config.version>2.2.7</checkstyle-config.version>
     <checkstyle.version>8.43</checkstyle.version>
     <spring-boot-thin-layout.version>1.0.27.RELEASE</spring-boot-thin-layout.version>
     <asciidoctor-maven-plugin.version>2.1.0</asciidoctor-maven-plugin.version>
-    <aws.sdk.version>2.16.83</aws.sdk.version>
+    <aws.sdk.version>2.16.85</aws.sdk.version>
     <embedded-database-spring-test.version>1.6.3</embedded-database-spring-test.version>
     <s3mock.version>0.2.6</s3mock.version>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -14,38 +14,33 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>2.3.7.RELEASE</version>
+    <version>2.5.0</version>
     <relativePath />
   </parent>
 
   <properties>
-    <aurora.starters.version>1.0.10</aurora.starters.version>
+    <aurora.starters.version>1.2.1</aurora.starters.version>
     <java.version>11</java.version>
     <maven.min-version>3.5.0</maven.min-version>
-
     <sonar.java.coveragePlugin>jacoco</sonar.java.coveragePlugin>
     <sonar.coverage.exclusions>**/*Main.java</sonar.coverage.exclusions>
     <sonar.tests>src/test/groovy</sonar.tests>
     <sonar-maven-plugin.version>3.7.0.1746</sonar-maven-plugin.version>
-
-    <gmavenplus-plugin.version>1.12.0</gmavenplus-plugin.version>
+    <gmavenplus-plugin.version>1.12.1</gmavenplus-plugin.version>
+    <groovy.version>2.5.14</groovy.version>
     <spock.version>1.3-groovy-2.5</spock.version>
     <cglib-nodep.version>3.3.0</cglib-nodep.version>
-    <pitest-maven.version>1.6.1</pitest-maven.version>
-    <jacoco-maven-plugin.version>0.8.6</jacoco-maven-plugin.version>
-
+    <pitest-maven.version>1.6.7</pitest-maven.version>
+    <jacoco-maven-plugin.version>0.8.7</jacoco-maven-plugin.version>
     <maven-enforcer-plugin.version>1.4.1</maven-enforcer-plugin.version>
     <maven-site-plugin.version>3.9.1</maven-site-plugin.version>
-
     <maven-checkstyle-plugin.version>3.1.1</maven-checkstyle-plugin.version>
     <checkstyle-config.version>2.2.7</checkstyle-config.version>
-    <checkstyle.version>8.38</checkstyle.version>
-
-    <spring-boot-thin-layout.version>1.0.26.RELEASE</spring-boot-thin-layout.version>
+    <checkstyle.version>8.43</checkstyle.version>
+    <spring-boot-thin-layout.version>1.0.27.RELEASE</spring-boot-thin-layout.version>
     <asciidoctor-maven-plugin.version>2.1.0</asciidoctor-maven-plugin.version>
-
-    <aws.sdk.version>2.15.45</aws.sdk.version>
-    <embedded-database-spring-test.version>1.6.1</embedded-database-spring-test.version>
+    <aws.sdk.version>2.16.83</aws.sdk.version>
+    <embedded-database-spring-test.version>1.6.3</embedded-database-spring-test.version>
     <s3mock.version>0.2.6</s3mock.version>
   </properties>
 
@@ -328,6 +323,27 @@
       <version>${aurora.starters.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-jdbc</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.postgresql</groupId>
+      <artifactId>postgresql</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.flywaydb</groupId>
+      <artifactId>flyway-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>s3</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.springframework.restdocs</groupId>
       <artifactId>spring-restdocs-mockmvc</artifactId>
       <scope>test</scope>
@@ -352,33 +368,8 @@
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-web</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-jdbc</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.postgresql</groupId>
-      <artifactId>postgresql</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.flywaydb</groupId>
-      <artifactId>flyway-core</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.glassfish.jaxb</groupId>
-      <artifactId>jaxb-runtime</artifactId>
-      <version>2.3.3</version>
-    </dependency>
-    <dependency>
-      <groupId>software.amazon.awssdk</groupId>
-      <artifactId>s3</artifactId>
     </dependency>
     <dependency>
       <groupId>io.findify</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
   </parent>
 
   <properties>
-    <aurora.starters.version>1.2.1</aurora.starters.version>
+    <aurora.starters.version>1.2.2</aurora.starters.version>
     <java.version>11</java.version>
     <maven.min-version>3.5.0</maven.min-version>
     <sonar.java.coveragePlugin>jacoco</sonar.java.coveragePlugin>

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -22,7 +22,9 @@ logging:
 
 ---
 spring:
-  profiles: local
+  config:
+    activate:
+      on-profile: local
   datasource:
     url: ${refapp.datasource.url:jdbc:postgresql://localhost:5432/refapp}
     username: ${refapp.datasource.username:postgres}

--- a/src/test/groovy/no/skatteetaten/aurora/openshift/reference/springboot/service/CounterDatabaseServiceTest.groovy
+++ b/src/test/groovy/no/skatteetaten/aurora/openshift/reference/springboot/service/CounterDatabaseServiceTest.groovy
@@ -7,8 +7,10 @@ import org.springframework.jdbc.core.JdbcTemplate
 import io.zonky.test.db.AutoConfigureEmbeddedDatabase
 import spock.lang.Specification
 
+import static io.zonky.test.db.AutoConfigureEmbeddedDatabase.DatabaseProvider.ZONKY
+
 @JdbcTest
-@AutoConfigureEmbeddedDatabase
+@AutoConfigureEmbeddedDatabase(provider = ZONKY)
 class CounterDatabaseServiceTest extends Specification {
 
   @Autowired


### PR DESCRIPTION
Use aurora-spring-boot-mvc-starter 1.2.1.
Update to spring boot parent 2.5.0.
Bump various dependencies.

NB! Use groovy version 2.5 in order to continue with spock 1 

https://jira.sits.no/browse/AOS-5764