### PR TITLE
Kjøre systemtester i affiliation aurora

### DIFF
--- a/Jenkinsfile-systemtest
+++ b/Jenkinsfile-systemtest
@@ -4,6 +4,7 @@ def config = [
     scriptVersion           : 'v7',
     pipelineScript          : 'https://git.aurora.skead.no/scm/ao/aurora-pipeline-scripts.git',
     affiliation             : 'aurora',
+    segment                 : 'aup',
     credentialsId           : "github",
     javaVersion             : 11,
     openShiftSleepAfterSetup: 90,

--- a/Jenkinsfile-systemtest
+++ b/Jenkinsfile-systemtest
@@ -3,7 +3,7 @@
 def config = [
     scriptVersion           : 'v7',
     pipelineScript          : 'https://git.aurora.skead.no/scm/ao/aurora-pipeline-scripts.git',
-    affiliation    : 'aup',
+    affiliation             : 'aurora',
     credentialsId           : "github",
     javaVersion             : 11,
     openShiftSleepAfterSetup: 90,


### PR DESCRIPTION
Endret affiliation til "aurora".
Segment er fremdeles "aup".

Link til systemteser på Jenkins: https://jenkins-aurora-build.utv.paas.skead.no/job/isolert-systemtest/job/openshift-reference-springboot-server/job/aos-5783/

Måtte også endre navn på objectArea i AuroraConfig for å få konfigurert S3Client. Se https://git.aurora.skead.no/projects/AC/repos/aurora/diff/st-refapp/referanse.json?until=eedbf81694812824dd52b7f81cca8626dba21d49
Er dette riktig? 